### PR TITLE
Fix accessing error in response

### DIFF
--- a/src/Replicate.php
+++ b/src/Replicate.php
@@ -60,7 +60,7 @@ class Replicate extends Connector
         }
 
         if ($prediction->json('status') === 'failed') {
-            throw new \Exception('Prediction failed: ' . $prediction->error);
+            throw new \Exception('Prediction failed: ' . $prediction->json('error'));
         }
 
         return $prediction->json('output');
@@ -117,7 +117,7 @@ class Replicate extends Connector
         }
 
         if ($updatedPrediction->json('status') === 'failed') {
-            throw new \Exception('Prediction failed: ' . $updatedPrediction['error']);
+            throw new \Exception('Prediction failed: ' . $updatedPrediction->json('error'));
         }
 
         return $updatedPrediction;


### PR DESCRIPTION
The error of a failing response was not accessed properly causing either one of the following errors.

> Undefined property: Saloon\Http\Response::$error

> Cannot use object of type Saloon\Http\Response as array