### PR TITLE
Fix status check in wait method

### DIFF
--- a/src/Replicate.php
+++ b/src/Replicate.php
@@ -95,7 +95,7 @@ class Replicate extends Connector
             throw new \Exception('Invalid prediction');
         }
 
-        if (in_array($prediction->json('id'), ['succeeded', 'failed', 'canceled'])) {
+        if (in_array($prediction->json('status'), ['succeeded', 'failed', 'canceled'])) {
             return $prediction;
         }
 


### PR DESCRIPTION
In the wait method the id instead of the status is used to check if the prediction finished